### PR TITLE
Fix `__contains__` on tuple pk searches

### DIFF
--- a/fastlite/kw.py
+++ b/fastlite/kw.py
@@ -59,7 +59,7 @@ def get(self:Table, pk_values: list|tuple|str|int, as_cls:bool=True)->Any:
     if not isinstance(pk_values, (list, tuple)): pk_values = [pk_values]
     last_pk = pk_values[0] if len(self.pks) == 1 else pk_values
     xtra = getattr(self, 'xtra_id', {})
-    vals = pk_values + list(xtra.values())
+    vals = list(pk_values) + list(xtra.values())
     pks = self.pks + list(xtra.keys())
     if len(pks)!=len(vals): raise NotFoundError(f"Need {len(pks)} pk")
     wheres = ["[{}] = ?".format(pk_name) for pk_name in pks]


### PR DESCRIPTION
As lists cannot be added to tuples and vice-versa, we cast `pk_values` to a list.

```python
Python 3.10.6 (main, Dec 12 2023, 14:13:45) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> [] + ()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: can only concatenate list (not "tuple") to list
>>> () + []
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: can only concatenate tuple (not "list") to tuple
```